### PR TITLE
fix: move mocks to src directory

### DIFF
--- a/src/Facades/RecaptchaEnterprise.php
+++ b/src/Facades/RecaptchaEnterprise.php
@@ -8,7 +8,7 @@ use Closure;
 use Illuminate\Support\Facades\Facade;
 use Oneduo\RecaptchaEnterprise\Contracts\RecaptchaContract;
 use Oneduo\RecaptchaEnterprise\Services\RecaptchaService;
-use Oneduo\RecaptchaEnterprise\Tests\Mocks\FakeRecaptchaEnterprise;
+use Oneduo\RecaptchaEnterprise\Mocks\FakeRecaptchaEnterprise;
 
 /**
  * @method static static setThreshold(float $threshold)

--- a/src/Mocks/FakeRecaptchaEnterprise.php
+++ b/src/Mocks/FakeRecaptchaEnterprise.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace Oneduo\RecaptchaEnterprise\Tests\Mocks;
+namespace Oneduo\RecaptchaEnterprise\Mocks;
 
 use Carbon\CarbonInterval;
 use Google\Cloud\RecaptchaEnterprise\V1\TokenProperties;

--- a/src/Mocks/FakeRecaptchaEnterprise.php
+++ b/src/Mocks/FakeRecaptchaEnterprise.php
@@ -10,6 +10,9 @@ use Illuminate\Support\Carbon;
 use Oneduo\RecaptchaEnterprise\Contracts\RecaptchaContract;
 use RuntimeException;
 
+/**
+ * @codeCoverageIgnore
+ */
 class FakeRecaptchaEnterprise implements RecaptchaContract
 {
     public ?float $threshold;

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -6,7 +6,7 @@ namespace Oneduo\RecaptchaEnterprise\Tests;
 
 use Oneduo\RecaptchaEnterprise\Contracts\RecaptchaContract;
 use Oneduo\RecaptchaEnterprise\RecaptchaEnterpriseServiceProvider;
-use Oneduo\RecaptchaEnterprise\Tests\Mocks\FakeRecaptchaEnterprise;
+use Oneduo\RecaptchaEnterprise\Mocks\FakeRecaptchaEnterprise;
 use Orchestra\Testbench\TestCase as Orchestra;
 
 class TestCase extends Orchestra


### PR DESCRIPTION
Hi !

When I install this project with composer, I have this error:
```
   Error 

  Class "Oneduo\RecaptchaEnterprise\Tests\Mocks\FakeRecaptchaEnterprise" not found

  at vendor/oneduo/laravel-recaptcha-enterprise/src/Facades/RecaptchaEnterprise.php:41
     37▕ 
     38▕     public static function fake(bool $alwaysValid = null, ?Closure $callback = null): RecaptchaContract
     39▕     {
     40▕         return tap(static::getFacadeRoot(), function (RecaptchaService $fake) use ($alwaysValid, $callback) {
  ➜  41▕             static::swap(is_callable($callback) ? $callback($fake) : new FakeRecaptchaEnterprise($alwaysValid));
     42▕         });
     43▕     }
     44▕ }
     45▕ 

      +21 vendor frames 
  22  artisan:37
      Illuminate\Foundation\Console\Kernel::handle()
Script @php artisan ide-helper:generate handling the post-update-cmd event returned with error code 1
```

When I check in vendor files, `vendor/oneduo/laravel-recaptcha-enterprise/tests` is missing. So I move Mocks directory to src